### PR TITLE
Fix possible buffer overrun on Audio signal channel string

### DIFF
--- a/source/groove.cpp
+++ b/source/groove.cpp
@@ -235,7 +235,7 @@ xgroove::xgroove(int argc,const t_atom *argv):
 	AddInFloat("Starting point"); // min play pos
 	AddInFloat("Ending point"); // max play pos
 	for(int ci = 0; ci < outchns; ++ci) {
-		char tmp[30];
+		char tmp[32];
 		STD::sprintf(tmp,"Audio signal channel %i",ci+1); 
 		AddOutSignal(tmp); // output
 	}

--- a/source/play.cpp
+++ b/source/play.cpp
@@ -96,7 +96,7 @@ xplay::xplay(int argc,const t_atom *argv)
 
     AddInSignal("Messages and Signal of playing position");  // pos signal
 	for(int ci = 0; ci < outchns; ++ci) {
-		char tmp[60];
+		char tmp[32];
 		STD::sprintf(tmp,"Audio signal channel %i",ci+1); 
 		AddOutSignal(tmp);
 	}


### PR DESCRIPTION
GCC warns about a possible buffer overrun:

```
source/groove.cpp: In constructor ‘xgroove::xgroove(int, const t_atom*)’:
source/groove.cpp:243:56: warning: ‘%i’ directive writing between 1 and 10 bytes into a region of size 9 [-Wformat-overflow=]
  243 |                 STD::sprintf(tmp,"Audio signal channel %i",ci+1);
      |                                                        ^~
source/groove.cpp:243:34: note: directive argument in the range [1, 2147483647]
  243 |                 STD::sprintf(tmp,"Audio signal channel %i",ci+1);
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~
```

Commit 770fd996821fd515f88d459a6a8a07ac05ce130f fixed one instance of the code in `play.cpp` but did not fix `grove.cpp`.

Increase the buffer by the needed byte and use the same value for the duplicate code.